### PR TITLE
Fix generation of secret keys

### DIFF
--- a/lib/rb-pure25519.rb
+++ b/lib/rb-pure25519.rb
@@ -3,6 +3,7 @@
 #
 
 require 'prime'
+require 'securerandom'
 
 
 


### PR DESCRIPTION
rb-pure25519.rb is missing a require 'securerandom' at the top of the
file; the method random_secret_str uses SecureRandom.

Workaround: Doing the missing require in application code.

You may want to bump the version to 1.0.3.